### PR TITLE
Use latest image instead of latest-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ kind-deploy-controller-dev:
 	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"image\":\"$(REGISTRY)/$(IMG):$(TAG)\"}]}}}}" --kubeconfig=$(PWD)/kubeconfig_managed
 	kubectl rollout status -n $(KIND_NAMESPACE) deployment $(IMG) --timeout=180s --kubeconfig=$(PWD)/kubeconfig_managed
 	# Workaround to properly set E2E image to local image
-	sed -i 's%quay.io/open-cluster-management/governance-policy-spec-sync:latest-dev%$(REGISTRY)/$(IMG):$(TAG)%' test/resources/case2_uninstall_ns/case2-uninstall-ns.yaml
+	sed -i 's%quay.io/open-cluster-management/governance-policy-spec-sync:latest%$(REGISTRY)/$(IMG):$(TAG)%' test/resources/case2_uninstall_ns/case2-uninstall-ns.yaml
 	sed -i 's%imagePullPolicy: "Always"%imagePullPolicy: "Never"%' test/resources/case2_uninstall_ns/case2-uninstall-ns.yaml
 	
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: governance-policy-spec-sync
       containers:
         - name: governance-policy-spec-sync
-          image: quay.io/open-cluster-management/governance-policy-spec-sync:latest-dev
+          image: quay.io/open-cluster-management/governance-policy-spec-sync:latest
           command:
           - governance-policy-spec-sync
           args:

--- a/test/resources/case2_uninstall_ns/case2-uninstall-ns.yaml
+++ b/test/resources/case2_uninstall_ns/case2-uninstall-ns.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: governance-policy-spec-sync
       containers:
       - name: uninstall-ns
-        image: "quay.io/open-cluster-management/governance-policy-spec-sync:latest-dev"
+        image: "quay.io/open-cluster-management/governance-policy-spec-sync:latest"
         imagePullPolicy: "Always"
         command: ["uninstall-ns"]
         args: 


### PR DESCRIPTION
The latest-dev image hasn't been updated in months. We are now using
latest for our newest images.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>