### PR TITLE
Sync the policy-encryption-key secret from the Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,18 @@ make e2e-test
 make kind-delete-cluster
 ```
 
-### Updating operator.yaml
+### deploy/operator.yaml
 
 The `deploy/operator.yaml` file is generated via Kustomize. The `deploy/rbac` directory of
 Kustomize files is managed by the operator-sdk and Kubebuilder using
 [markers](https://book.kubebuilder.io/reference/markers.html). After updating the markers or
 any of the Kustomize files, you may regenerate `deploy/operator.yaml` by running
 `make generate-operator-yaml`.
+
+The `secret-sync` controller requires access to get, create, update, and delete Secret objects in
+the managed cluster namespace. Since the managed cluster namespace is not known at build time, the
+configuration in `deploy/operator.yaml` grants this access cluster wide. In a production
+environment, limit this to just the managed cluster namespace.
 
 ## References
 

--- a/controllers/secretsync/secret_sync.go
+++ b/controllers/secretsync/secret_sync.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package secretsync
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	ControllerName = "secret-sync"
+	SecretName     = "policy-encryption-key"
+)
+
+var log = logf.Log.WithName(ControllerName)
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		Complete(r)
+}
+
+// blank assignment to verify that ReconcilePolicy implements reconcile.Reconciler
+var _ reconcile.Reconciler = &SecretReconciler{}
+
+type SecretReconciler struct {
+	client.Client
+	ManagedClient client.Client
+	Scheme        *runtime.Scheme
+}
+
+// WARNING: In production, this should be namespaced to the actual managed cluster namespace.
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=create
+//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=delete;get;update
+
+// Reconcile handles updates to the "policy-encryption-key" Secret in the managed cluster namespace on the Hub.
+// The method is responsible for synchronizing the Secret to the managed cluster namespace on the managed cluster.
+func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.V(1).Info("Reconciling Secret")
+	// The cache configuration of SelectorsByObject should prevent this from happening, but add this as a precaution.
+	if request.Name != SecretName {
+		log.Info("Got a reconciliation request for an unexpected Secret. This should have been filtered out.")
+
+		return reconcile.Result{}, nil
+	}
+
+	hubEncryptionSecret := &corev1.Secret{}
+
+	err := r.Get(ctx, request.NamespacedName, hubEncryptionSecret)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to get the Secret on the Hub. Requeueing the request.")
+
+			return reconcile.Result{}, err
+		}
+
+		log.Info("The Secret is no longer on the Hub. Deleting the replicated Secret.")
+
+		err := r.ManagedClient.Delete(
+			ctx,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      request.Name,
+					Namespace: request.Namespace,
+				},
+			},
+		)
+		if err != nil && !errors.IsNotFound(err) {
+			log.Error(err, "Failed to delete the replicated Secret. Requeueing the request.")
+
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	managedEncryptionSecret := &corev1.Secret{}
+	err = r.ManagedClient.Get(ctx, request.NamespacedName, managedEncryptionSecret)
+
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to get the replicated Secret. Requeueing the request.")
+
+			return reconcile.Result{}, err
+		}
+
+		// Don't completely copy the Hub secret since it isn't desired to have any annotations related to disaster
+		// recovery copied over.
+		managedEncryptionSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      request.Name,
+				Namespace: request.Namespace,
+			},
+			Data: hubEncryptionSecret.Data,
+		}
+
+		err := r.ManagedClient.Create(ctx, managedEncryptionSecret)
+		if err != nil {
+			log.Error(err, "Failed to replicate the Secret. Requeueing the request.")
+
+			return reconcile.Result{}, err
+		}
+
+		reqLogger.V(1).Info("Reconciliation complete")
+
+		return reconcile.Result{}, nil
+	}
+
+	if !equality.Semantic.DeepEqual(hubEncryptionSecret.Data, managedEncryptionSecret.Data) {
+		log.V(1).Info("Updating the replicated secret due to it not matching the source on the Hub")
+
+		managedEncryptionSecret.Data = hubEncryptionSecret.Data
+
+		err := r.ManagedClient.Update(ctx, managedEncryptionSecret)
+		if err != nil {
+			log.Error(err, "Failed to update the replicated Secret. Requeueing the request.")
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	reqLogger.V(1).Info("Reconciliation complete")
+
+	return reconcile.Result{}, nil
+}

--- a/controllers/secretsync/secret_sync_test.go
+++ b/controllers/secretsync/secret_sync_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package secretsync
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	clusterName = "managed"
+	keySize     = 256
+	secretName  = "policy-encryption-key"
+)
+
+func getTestSecret() *corev1.Secret {
+	// Generate an AES-256 key and stored it as a Secret on the Hub.
+	key := make([]byte, keySize/8)
+	_, err := rand.Read(key)
+	Expect(err).To(BeNil())
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: clusterName,
+		},
+		Data: map[string][]byte{
+			"key": key,
+		},
+	}
+}
+
+func TestReconcileSecretHubOnly(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := getTestSecret()
+	hubClient := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+	managedClient := fake.NewClientBuilder().Build()
+
+	r := SecretReconciler{Client: hubClient, ManagedClient: managedClient, Scheme: scheme.Scheme}
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: secretName, Namespace: clusterName},
+	}
+	_, err := r.Reconcile(context.TODO(), request)
+	Expect(err).To(BeNil())
+
+	// Verify that the Secret was synced to the managed cluster by the Reconciler.
+	managedEncryptionSecret := &corev1.Secret{}
+	err = managedClient.Get(context.TODO(), request.NamespacedName, managedEncryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(len(managedEncryptionSecret.Data["key"])).To(Equal(keySize / 8))
+}
+
+func TestReconcileSecretAlreadySynced(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := getTestSecret()
+	hubClient := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+	managedClient := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+
+	managedEncryptionSecret := &corev1.Secret{}
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: secretName, Namespace: clusterName},
+	}
+	err := managedClient.Get(context.TODO(), request.NamespacedName, managedEncryptionSecret)
+	Expect(err).To(BeNil())
+
+	version := managedEncryptionSecret.ObjectMeta.ResourceVersion
+
+	r := SecretReconciler{Client: hubClient, ManagedClient: managedClient, Scheme: scheme.Scheme}
+	_, err = r.Reconcile(context.TODO(), request)
+	Expect(err).To(BeNil())
+
+	// Verify that the Secret was not modified by the Reconciler.
+	managedEncryptionSecret = &corev1.Secret{}
+	err = managedClient.Get(context.TODO(), request.NamespacedName, managedEncryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(managedEncryptionSecret.ResourceVersion).To(Equal(version))
+}
+
+func TestReconcileSecretMismatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	hubEncryptionSecret := getTestSecret()
+	hubClient := fake.NewClientBuilder().WithObjects(hubEncryptionSecret).Build()
+	managedEncryptionSecret := getTestSecret()
+	managedEncryptionSecret.Data["key"] = []byte{byte('A')}
+	managedClient := fake.NewClientBuilder().WithObjects(managedEncryptionSecret).Build()
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: secretName, Namespace: clusterName},
+	}
+
+	r := SecretReconciler{Client: hubClient, ManagedClient: managedClient, Scheme: scheme.Scheme}
+	_, err := r.Reconcile(context.TODO(), request)
+	Expect(err).To(BeNil())
+
+	// Verify that the Secret was updated by the Reconciler.
+	managedEncryptionSecret = &corev1.Secret{}
+	err = managedClient.Get(context.TODO(), request.NamespacedName, managedEncryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(len(managedEncryptionSecret.Data["key"])).To(Equal(keySize / 8))
+}
+
+func TestReconcileSecretDeletedOnHub(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := getTestSecret()
+	hubClient := fake.NewClientBuilder().Build()
+	managedClient := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+
+	r := SecretReconciler{Client: hubClient, ManagedClient: managedClient, Scheme: scheme.Scheme}
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: secretName, Namespace: clusterName},
+	}
+	_, err := r.Reconcile(context.TODO(), request)
+	Expect(err).To(BeNil())
+
+	// Verify that the Secret was deleted on the managed cluster by the Reconciler.
+	managedEncryptionSecret := &corev1.Secret{}
+	err = managedClient.Get(context.TODO(), request.NamespacedName, managedEncryptionSecret)
+	Expect(errors.IsNotFound(err)).To(BeTrue())
+}
+
+// The tested code should occur in production because of the field selector set on the watch, but
+// the code should still account for it.
+func TestReconcileInvalidSecretName(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := getTestSecret()
+	encryptionSecret.ObjectMeta.Name = "not-the-secret"
+	hubClient := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+	managedClient := fake.NewClientBuilder().Build()
+
+	r := SecretReconciler{Client: hubClient, ManagedClient: managedClient, Scheme: scheme.Scheme}
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "not-the-secret", Namespace: clusterName},
+	}
+	_, err := r.Reconcile(context.TODO(), request)
+	Expect(err).To(BeNil())
+
+	// Verify that the Secret was not synced to the managed cluster by the Reconciler.
+	managedEncryptionSecret := &corev1.Secret{}
+	err = managedClient.Get(context.TODO(), request.NamespacedName, managedEncryptionSecret)
+	Expect(errors.IsNotFound(err)).To(BeTrue())
+}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -69,6 +69,22 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - update
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - policies

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -27,6 +27,22 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - update
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - policies

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 
 	// to ensure that exec-entrypoint and run can make use of them.
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	//+kubebuilder:scaffold:imports
+	"github.com/stolostron/governance-policy-spec-sync/controllers/secretsync"
 	"github.com/stolostron/governance-policy-spec-sync/controllers/sync"
 	"github.com/stolostron/governance-policy-spec-sync/tool"
 	"github.com/stolostron/governance-policy-spec-sync/version"
@@ -135,6 +137,18 @@ func main() {
 	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events(namespace)})
 	managedRecorder := eventBroadcaster.NewRecorder(eventsScheme, v1.EventSource{Component: sync.ControllerName})
 
+	// Set a field selector so that a watch on secrets will be limited to just the secret with the policy template
+	// encryption key.
+	newCacheFunc := cache.BuilderWithOptions(
+		cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&v1.Secret{}: {
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": secretsync.SecretName}),
+				},
+			},
+		},
+	)
+
 	// Set default manager options
 	options := manager.Options{
 		Scheme:                 scheme,
@@ -146,6 +160,7 @@ func main() {
 		// Override LeaderElectionConfig to managed cluster config.
 		// Otherwise it will improperly use the hub cluster config for leader election.
 		LeaderElectionConfig: managedCfg,
+		NewCache:             newCacheFunc,
 	}
 
 	if tool.Options.LegacyLeaderElection {
@@ -179,7 +194,16 @@ func main() {
 		ManagedRecorder: managedRecorder,
 		Scheme:          mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		log.Error(err, "unable to create controller", "controller", sync.ControllerName)
+		log.Error(err, "Unable to create the controller", "controller", sync.ControllerName)
+		os.Exit(1)
+	}
+
+	if err = (&secretsync.SecretReconciler{
+		Client:        mgr.GetClient(),
+		ManagedClient: managedClient,
+		Scheme:        mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		log.Error(err, "Unable to create the controller", "controller", secretsync.ControllerName)
 		os.Exit(1)
 	}
 

--- a/test/e2e/case3_sync_secret_test.go
+++ b/test/e2e/case3_sync_secret_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/governance-policy-propagator/test/utils"
+
+	"github.com/stolostron/governance-policy-spec-sync/controllers/secretsync"
+)
+
+const (
+	case3SecretYAML          = "../resources/case3_sync_secret/secret.yaml"
+	case3UnrelatedSecretYAML = "../resources/case3_sync_secret/unrelated_secret.yaml"
+)
+
+var _ = Describe("Test spec sync", func() {
+	AfterEach(func() {
+		By("Deleting the test secrets on the Hub")
+		_, _ = utils.KubectlWithOutput(
+			"delete", "-f", case3SecretYAML, "-n", testNamespace, "--kubeconfig=../../kubeconfig_hub",
+		)
+		_, _ = utils.KubectlWithOutput(
+			"delete", "-f", case3UnrelatedSecretYAML, "-n", testNamespace, "--kubeconfig=../../kubeconfig_hub",
+		)
+	})
+
+	It("should sync the secret to the managed cluster when created on the hub", func() {
+		_, _ = utils.KubectlWithOutput(
+			"apply", "-f", case3SecretYAML, "-n", testNamespace, "--kubeconfig=../../kubeconfig_hub",
+		)
+		managedSecret := utils.GetWithTimeout(
+			clientManagedDynamic,
+			gvrSecret,
+			secretsync.SecretName,
+			testNamespace,
+			true,
+			defaultTimeoutSeconds,
+		)
+		Expect(managedSecret).NotTo(BeNil())
+	})
+
+	It("should not sync the unrelated secret to the managed cluster when created on the hub", func() {
+		_, _ = utils.KubectlWithOutput(
+			"apply", "-f", case3UnrelatedSecretYAML, "-n", testNamespace, "--kubeconfig=../../kubeconfig_hub",
+		)
+		// Sleep 5 seconds to ensure the secret isn't synced.
+		time.Sleep(5 * time.Second)
+		managedSecret := utils.GetWithTimeout(
+			clientManagedDynamic,
+			gvrSecret,
+			"not-the-policy-encryption-key",
+			testNamespace,
+			false,
+			defaultTimeoutSeconds,
+		)
+		Expect(managedSecret).To(BeNil())
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -34,6 +34,7 @@ var (
 	gvrPolicy             schema.GroupVersionResource
 	gvrPlacementBinding   schema.GroupVersionResource
 	gvrPlacementRule      schema.GroupVersionResource
+	gvrSecret             schema.GroupVersionResource
 	kubeconfigHub         string
 	kubeconfigManaged     string
 	defaultTimeoutSeconds int
@@ -78,6 +79,10 @@ var _ = BeforeSuite(func() {
 		Group:    "apps.open-cluster-management.io",
 		Version:  "v1",
 		Resource: "placementrules",
+	}
+	gvrSecret = schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "secrets",
 	}
 	clientHub = NewKubeClient("", kubeconfigHub, "")
 	clientHubDynamic = NewKubeClientDynamic("", kubeconfigHub, "")

--- a/test/resources/case3_sync_secret/secret.yaml
+++ b/test/resources/case3_sync_secret/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-encryption-key
+  namespace: managed
+data:
+  key: hBwJp0pKH8wSBw1fqm1adfQdHe5Va3XQEySDGI4yYQc=

--- a/test/resources/case3_sync_secret/unrelated_secret.yaml
+++ b/test/resources/case3_sync_secret/unrelated_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: not-the-policy-encryption-key
+  namespace: managed
+data:
+  key: hBwJp0pKH8wSBw1fqm1adfQdHe5Va3XQEySDGI4yYQc=


### PR DESCRIPTION
Add the secret-sync controller which responds to updates to the
policy-encryption-key secret in the managed cluster namespace on the
Hub. The controller is responsible for keeping a copy in sync of that
secret in the managed cluster namespace on the managed cluster.

Resolves:
https://github.com/stolostron/backlog/issues/18713