### PR TITLE
Backport owner update to release 2.3

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,8 +5,6 @@ approvers:
 - gparvin
 - JustinKuli
 - willkutler
-- ycao56
-
 reviewers:
 - ChunxiAlexLuo
 - ckandag
@@ -14,4 +12,3 @@ reviewers:
 - gparvin
 - JustinKuli
 - willkutler
-- ycao56


### PR DESCRIPTION
Manual backport due to cherry pick failure

Signed-off-by: Gus Parvin <gparvin@redhat.com>